### PR TITLE
Migrated to Django 1.8

### DIFF
--- a/avatar_crop/urls.py
+++ b/avatar_crop/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('avatar_crop.views',
     url(r'^crop/(\d+)/$', 'avatar_crop', name='avatar_crop'),

--- a/avatar_crop/views.py
+++ b/avatar_crop/views.py
@@ -1,6 +1,5 @@
 import os
 
-from django.conf import settings
 from django.core.files.base import ContentFile
 from django.shortcuts import render_to_response
 from django.template import RequestContext
@@ -25,7 +24,7 @@ from avatar_crop.forms import AvatarForm, AvatarCropForm
 from avatar.models import Avatar
 
 from avatar_crop import AVATAR_CROP_MAX_SIZE
-from avatar.settings import AVATAR_STORAGE_DIR, AVATAR_THUMB_QUALITY, AVATAR_THUMB_FORMAT
+from avatar.conf import settings
 
 @login_required
 def avatar_crop(request, id=None):
@@ -70,7 +69,7 @@ def avatar_crop(request, id=None):
                 image = image.convert('RGB')
 
             thumb = StringIO()
-            image.save(thumb, AVATAR_THUMB_FORMAT, quality=AVATAR_THUMB_QUALITY)
+            image.save(thumb, settings.AVATAR_THUMB_FORMAT, quality=settings.AVATAR_THUMB_QUALITY)
             thumb_file = ContentFile(thumb.getvalue())
 
             base_name, ext = os.path.splitext(avatar.avatar.name)

--- a/sample_project/manage.py
+++ b/sample_project/manage.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+from django.core.management import execute_from_command_line
+import os
+import sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    execute_from_command_line(sys.argv)

--- a/sample_project/requirements.txt
+++ b/sample_project/requirements.txt
@@ -1,2 +1,2 @@
-Django==1.3.1
--e git://github.com/ericflo/django-avatar.git#egg=django_avatar
+Django==1.8.4
+django-avatar==2.1.1

--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -74,8 +74,8 @@ SECRET_KEY = 'n7)rr3uyu*tudvei)l5=yd*^ij_)m0(vvh7%=p=r0lx6v(t@d#'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
 #     'django.template.loaders.eggs.load_template_source',
 )
 
@@ -84,6 +84,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
 )
 
 ROOT_URLCONF = 'urls'

--- a/sample_project/templates/avatar/change.html
+++ b/sample_project/templates/avatar/change.html
@@ -4,7 +4,7 @@
 {% block body %}
     <p>Your current avatar: </p>
     {% avatar user %}
-    <a href="{% url avatar_crop_default %}">Crop</a>
+    <a href="{% url 'avatar_crop_default' %}">Crop</a>
     {% if not avatars %}
         <p>You do not yet have an avatar.  Please upload one now.</p>
     {% else %}
@@ -15,7 +15,7 @@
             <input type="submit" value="Choose new Default" />
         </form>
     {% endif %}
-    <form enctype="multipart/form-data" method="POST" action="{% url avatar_add %}">{% csrf_token %}
+    <form enctype="multipart/form-data" method="POST" action="{% url 'avatar_add' %}">{% csrf_token %}
         <input type="file" name="avatar" value="Avatar Image" />
         <input type="submit" value="Upload New Image" />
     </form>

--- a/sample_project/templates/base.html
+++ b/sample_project/templates/base.html
@@ -29,9 +29,9 @@
     <div class="container">
         <div class="nav">
              <ul>
-                <li><a href="{% url avatar_add %}">Add</a></li>
-                <li><a href="{% url avatar_change %}">Change</a></li>
-                <li><a href="{% url avatar_delete %}">Delete</a></li>
+                <li><a href="{% url 'avatar_add' %}">Add</a></li>
+                <li><a href="{% url 'avatar_change' %}">Change</a></li>
+                <li><a href="{% url 'avatar_delete' %}">Delete</a></li>
              </ul>
         </div>
         {% block body %}

--- a/sample_project/templates/registration/login.html
+++ b/sample_project/templates/registration/login.html
@@ -6,7 +6,7 @@
 <p>Your username and password didn't match. Please try again.</p>
 {% endif %}
 
-<form method="post" action="{% url django.contrib.auth.views.login %}">{% csrf_token %}
+<form method="post" action="{% url 'django.contrib.auth.views.login' %}">{% csrf_token %}
 <table>
 <tr>
     <td>{{ form.username.label_tag }}</td>

--- a/sample_project/urls.py
+++ b/sample_project/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls.defaults import url, patterns, include
+from django.conf.urls import url, patterns, include
+from django.views.generic.base import RedirectView
 
 from django.contrib import admin
-admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),
@@ -9,7 +9,7 @@ urlpatterns = patterns('',
     url(r'^avatar_crop/', include('avatar_crop.urls')),
     url(r'^accounts/login/', 'django.contrib.auth.views.login', name='auth_login'),
     url(r'^accounts/logout/', 'django.contrib.auth.views.logout', name='auth_logout'),
-    url(r'^$', 'django.views.generic.simple.redirect_to', {'url': '/avatar/change/'}),
+    url(r'^$', RedirectView.as_view(url='/avatar/change/')),
 )
 
 from django.conf import settings


### PR DESCRIPTION
Following changes were made
- Don't install django-avatar from github anymore. Install latest
  django-avatar from pypi.
- Changed views.py of django-avatar-crop in accordance with latest
  django-avatar
- Url names should be in quotes
- Changed manage.py and settings.py to confirm with Django 1.8
